### PR TITLE
fix: get cid request method

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -33,7 +33,7 @@ func createTempDirWithFile(f []string) (*os.File, error) {
 }
 
 func GetCID(url string, payload io.Reader) (*http.Response, error) {
-	req, err := http.NewRequest(http.MethodGet, url, payload)
+	req, err := http.NewRequest(http.MethodPost, url, payload)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating HTTP request: %s", err)
 	}


### PR DESCRIPTION
The path `/api/v0/cat` should be requested with POST method, or the server will return 405 error.

refer to https://docs.ipfs.tech/reference/kubo/rpc/#api-v0-cat